### PR TITLE
Add no-entrypoint feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 
 [features]
+no-entrypoint = []
 test-bpf = []
 
 [dev-dependencies]

--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,5 +1,7 @@
 /* SQUADS */
 
+#![cfg(not(feature = "no-entrypoint"))]
+
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
 };


### PR DESCRIPTION
This is to resolve this error:
```error: the `#[global_allocator]` in this crate conflicts with global allocator in: squads_program```
when including the repository as a dependency of another Solana program.

The approach that seems standard across SPL programs is to include a feature called `no-entrypoint` which disables the entrypoint macro which modifies the `global_allocator` (and does other unnecessary stuff when the code is just being used as a library).

This resolves the error locally after the changes:
```
Before: (FAILS with above error)
squads-program = { git = "https://github.com/squads-dapp/program" }

After: (no error with new feature enabled)
squads-program = { version = "2.0.1", path = "../../../squads-program", features = ["no-entrypoint"]}
```